### PR TITLE
feat(core): resource profiling integration for MLO-10

### DIFF
--- a/neuraldbg.py
+++ b/neuraldbg.py
@@ -298,7 +298,12 @@ class NeuralDbg:
                         from_state="NONE",
                         to_state=current_health.value,
                         confidence=1.0,
-                        metadata=activation_stats
+                        metadata={
+                            **activation_stats,
+                            'resources': resource_snapshot,
+                            'memory_spike': False,
+                            'memory_spike_keys': [],
+                        }
                     )
                     self.events.append(event)
                     if current_health != ActivationHealth.NORMAL:
@@ -365,7 +370,10 @@ class NeuralDbg:
                         confidence=1.0,
                         metadata={
                             'current_norm': grad_norm,
-                            'transition_type': 'baseline'
+                            'transition_type': 'baseline',
+                            'resources': resource_snapshot,
+                            'memory_spike': False,
+                            'memory_spike_keys': [],
                         }
                     )
                     self.events.append(event)

--- a/neuraldbg.py
+++ b/neuraldbg.py
@@ -146,6 +146,19 @@ class NeuralDbg:
         self.step = 0
         self.is_monitoring = False
 
+        # Resource profiling — psutil is optional but treated as a runtime dep
+        self._psutil_process = None
+        try:
+            import psutil as _psutil
+            self._psutil_process = _psutil.Process()
+        except ImportError:
+            pass
+
+        # Per-step resource snapshot cache: (step, snapshot) — sampled once per step
+        self._resource_snapshot_cache: Optional[Tuple[int, Dict[str, float]]] = None
+        # Snapshot from the previous step used as spike baseline
+        self._resource_baseline: Dict[str, float] = {}
+
     def step_iteration(self):
         """Increment the internal step counter."""
         self.step += 1
@@ -245,15 +258,19 @@ class NeuralDbg:
                 activation_stats = self._compute_activation_stats(output)
                 current_health = self._classify_activation_health(activation_stats)
 
+                # Sample resources once per step (outside transition check to build baseline)
+                resource_snapshot, resource_baseline = self._get_step_resource_snapshot(output.device)
+
                 # Detect activation regime shifts
                 if layer_name in self.previous_activation_stats:
                     prev_stats = self.previous_activation_stats[layer_name]
                     prev_health = self._classify_activation_health(prev_stats)
-                    
+
                     if prev_health != current_health:
                         if current_health != ActivationHealth.NORMAL:
                             self._track_first_occurrence(f"activation_{current_health.value}", layer_name)
-                            
+
+                        is_spike, spike_keys = self._is_memory_spike(resource_snapshot, resource_baseline)
                         event = SemanticEvent(
                             event_type=EventType.ACTIVATION_REGIME_SHIFT,
                             layer_name=layer_name,
@@ -265,7 +282,10 @@ class NeuralDbg:
                                 'prev_saturation': prev_stats.get('saturation_ratio'),
                                 'current_saturation': activation_stats.get('saturation_ratio'),
                                 'prev_dead': prev_stats.get('dead_ratio'),
-                                'current_dead': activation_stats.get('dead_ratio')
+                                'current_dead': activation_stats.get('dead_ratio'),
+                                'resources': resource_snapshot,
+                                'memory_spike': is_spike,
+                                'memory_spike_keys': spike_keys,
                             }
                         )
                         self.events.append(event)
@@ -300,7 +320,11 @@ class NeuralDbg:
             # Extract gradient health information
             # In full_backward_hook, grad_output is a tuple of gradients w.r.t. outputs
             if grad_output and len(grad_output) > 0 and grad_output[0] is not None:
-                grad_norm = grad_output[0].norm().item()
+                grad_tensor = grad_output[0]
+                grad_norm = grad_tensor.norm().item()
+
+                # Sample resources once per step (outside transition check to build baseline)
+                resource_snapshot, resource_baseline = self._get_step_resource_snapshot(grad_tensor.device)
 
                 # Detect gradient health transitions
                 if layer_name in self.previous_gradient_norms:
@@ -311,6 +335,7 @@ class NeuralDbg:
                         if current_health != GradientHealth.HEALTHY:
                             self._track_first_occurrence(f"gradient_{current_health.value}", layer_name)
 
+                        is_spike, spike_keys = self._is_memory_spike(resource_snapshot, resource_baseline)
                         event = SemanticEvent(
                             event_type=EventType.GRADIENT_HEALTH_TRANSITION,
                             layer_name=layer_name,
@@ -321,7 +346,10 @@ class NeuralDbg:
                             metadata={
                                 'prev_norm': prev_norm,
                                 'current_norm': grad_norm,
-                                'transition_type': transition['type']
+                                'transition_type': transition['type'],
+                                'resources': resource_snapshot,
+                                'memory_spike': is_spike,
+                                'memory_spike_keys': spike_keys,
                             }
                         )
                         self.events.append(event)
@@ -406,6 +434,46 @@ class NeuralDbg:
         for hook in self.hooks:
             hook.remove()
         self.hooks.clear()
+
+    def _sample_resources(self, device: Optional[torch.device] = None) -> Dict[str, float]:
+        """Snapshot current CPU and (if relevant) GPU memory usage."""
+        stats: Dict[str, float] = {}
+        if self._psutil_process is not None:
+            try:
+                stats['cpu_memory_mb'] = self._psutil_process.memory_info().rss / 1024 ** 2
+            except Exception:
+                pass
+        if device is not None and device.type == 'cuda':
+            stats['gpu_memory_allocated_mb'] = torch.cuda.memory_allocated(device) / 1024 ** 2
+            stats['gpu_memory_reserved_mb'] = torch.cuda.memory_reserved(device) / 1024 ** 2
+        return stats
+
+    def _get_step_resource_snapshot(self, device: Optional[torch.device] = None) -> Tuple[Dict[str, float], Dict[str, float]]:
+        """Return (current_snapshot, baseline) for this step, sampling at most once per step."""
+        if self._resource_snapshot_cache is not None and self._resource_snapshot_cache[0] == self.step:
+            return self._resource_snapshot_cache[1], self._resource_baseline
+        # New step: promote previous snapshot to baseline, then take a fresh one
+        if self._resource_snapshot_cache is not None:
+            self._resource_baseline = self._resource_snapshot_cache[1]
+        snapshot = self._sample_resources(device)
+        self._resource_snapshot_cache = (self.step, snapshot)
+        return snapshot, self._resource_baseline
+
+    def _is_memory_spike(
+        self,
+        current: Dict[str, float],
+        baseline: Dict[str, float],
+    ) -> Tuple[bool, List[str]]:
+        """Detect spikes: >20 % relative rise AND >50 MB absolute vs previous-step baseline."""
+        spike_keys: List[str] = []
+        for key, curr_val in current.items():
+            if key not in baseline:
+                continue
+            prev_val = baseline[key]
+            delta = curr_val - prev_val
+            if prev_val > 0 and (delta / prev_val) > 0.20 and delta > 50.0:
+                spike_keys.append(key)
+        return bool(spike_keys), spike_keys
 
     def _get_layer_name(self, module: nn.Module) -> str:
         """Get the name of a module from the pre-computed mapping (O(1) lookup)."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.26.0",
     "torch>=2.0.0",
+    "psutil>=5.9,<6.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_event_unit.py
+++ b/tests/unit/test_event_unit.py
@@ -210,6 +210,103 @@ class TestCausalReasoning:
         assert coupling['step_difference'] == 2
 
 
+class TestResourceProfiling:
+    """Unit tests for resource profiling integration in NeuralDbg."""
+
+    def test_sample_resources_cpu(self, monkeypatch):
+        """cpu_memory_mb is populated when psutil is available."""
+        import types
+        model = nn.Linear(4, 2)
+        dbg = NeuralDbg(model)
+
+        # Monkeypatch a fake psutil process on the instance
+        fake_mem = types.SimpleNamespace(rss=200 * 1024 ** 2)  # 200 MB
+        fake_proc = types.SimpleNamespace(memory_info=lambda: fake_mem)
+        dbg._psutil_process = fake_proc
+
+        stats = dbg._sample_resources()
+        assert 'cpu_memory_mb' in stats
+        assert stats['cpu_memory_mb'] == pytest.approx(200.0)
+
+    def test_sample_resources_no_psutil(self):
+        """Sampling degrades gracefully when psutil is unavailable."""
+        model = nn.Linear(4, 2)
+        dbg = NeuralDbg(model)
+        dbg._psutil_process = None  # simulate absent psutil
+
+        stats = dbg._sample_resources()
+        assert 'cpu_memory_mb' not in stats
+
+    def test_memory_spike_detected(self):
+        """_is_memory_spike returns True when rise > 20 % and > 50 MB."""
+        model = nn.Linear(4, 2)
+        dbg = NeuralDbg(model)
+
+        baseline = {'cpu_memory_mb': 200.0}
+        current = {'cpu_memory_mb': 200.0 + 60.0}  # +60 MB = 30 % rise
+        is_spike, keys = dbg._is_memory_spike(current, baseline)
+        assert is_spike is True
+        assert 'cpu_memory_mb' in keys
+
+    def test_memory_spike_not_triggered_below_threshold(self):
+        """No spike when rise is < 50 MB even if percentage is high."""
+        model = nn.Linear(4, 2)
+        dbg = NeuralDbg(model)
+
+        baseline = {'cpu_memory_mb': 10.0}
+        current = {'cpu_memory_mb': 25.0}  # +15 MB — > 20 % but < 50 MB
+        is_spike, keys = dbg._is_memory_spike(current, baseline)
+        assert is_spike is False
+        assert keys == []
+
+    def test_event_metadata_contains_resources(self, monkeypatch):
+        """SemanticEvents emitted by hooks carry resources/memory_spike keys."""
+        import types
+        model = nn.Sequential(nn.Linear(4, 4), nn.Linear(4, 2))
+        dbg = NeuralDbg(model)
+
+        fake_mem = types.SimpleNamespace(rss=300 * 1024 ** 2)
+        dbg._psutil_process = types.SimpleNamespace(memory_info=lambda: fake_mem)
+
+        x = torch.randn(2, 4)
+        with dbg:
+            for step in range(3):
+                dbg.step = step
+                out = model(x)
+                loss = out.sum()
+                loss.backward()
+
+        for event in dbg.events:
+            assert 'resources' in event.metadata
+            assert 'memory_spike' in event.metadata
+            assert 'memory_spike_keys' in event.metadata
+            assert isinstance(event.metadata['memory_spike'], bool)
+
+    def test_step_snapshot_cached(self, monkeypatch):
+        """Resource snapshot is taken only once per step, not once per module."""
+        import types
+        call_count = {'n': 0}
+        model = nn.Linear(4, 2)
+        dbg = NeuralDbg(model)
+
+        original_sample = dbg._sample_resources
+
+        def counting_sample(device=None):
+            call_count['n'] += 1
+            return original_sample(device)
+
+        monkeypatch.setattr(dbg, '_sample_resources', counting_sample)
+
+        dbg.step = 0
+        dbg._get_step_resource_snapshot()
+        dbg._get_step_resource_snapshot()  # same step — should not call again
+        assert call_count['n'] == 1
+
+        dbg.step = 1
+        dbg._get_step_resource_snapshot()  # new step — should call once more
+        assert call_count['n'] == 2
+
+
 class TestIntegrationBasics:
     """Basic integration tests for NeuralDbg with simple models."""
 


### PR DESCRIPTION
## Summary

- Add lightweight CPU and GPU memory profiling to semantic events (MLO-10)
- Every `SemanticEvent` now carries `resources`, `memory_spike`, and `memory_spike_keys` in its metadata
- `_sample_resources()` captures `cpu_memory_mb` via psutil and `gpu_memory_allocated_mb` / `gpu_memory_reserved_mb` via `torch.cuda` when on CUDA
- `_get_step_resource_snapshot()` caches the snapshot once per step to avoid redundant sampling across layers
- `_is_memory_spike()` detects spikes: >20% relative rise AND >50 MB absolute vs previous-step baseline
- psutil is optional — degrades gracefully if absent (no cpu_memory_mb key)

## Acceptance Criteria (MLO-10)

- [x] Events capture memory spikes during activation regime shifts
- [x] Events capture memory spikes during gradient health transitions
- [x] Baseline (first-encounter) events also carry resource context
- [x] GPU memory tracked when device is CUDA
- [x] Sampling cached once per step — not once per module

## Test plan

- [x] `test_sample_resources_cpu` — psutil mock returns correct MB
- [x] `test_sample_resources_no_psutil` — graceful degradation
- [x] `test_memory_spike_detected` — spike above both thresholds detected
- [x] `test_memory_spike_not_triggered_below_threshold` — below 50 MB not flagged
- [x] `test_event_metadata_contains_resources` — all events carry resource keys
- [x] `test_step_snapshot_cached` — `_sample_resources` called once per step
- [x] Full suite: 89 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add lightweight CPU/GPU memory profiling to all semantic events to detect resource spikes and provide context during activation and gradient transitions (MLO-10). Sampling happens once per step to avoid per-layer overhead.

- **New Features**
  - Every `SemanticEvent` now includes `resources`, `memory_spike`, and `memory_spike_keys`.
  - Resource snapshot captures `cpu_memory_mb` via `psutil` and `gpu_memory_allocated_mb`/`gpu_memory_reserved_mb` via `torch.cuda` when on CUDA.
  - Memory spike detection uses >20% relative and >50 MB absolute rise vs the previous step’s baseline.
  - Snapshot is cached once per step; previous snapshot becomes the next step’s baseline.
  - Meets MLO-10: captures spikes on activation regime shifts and gradient health transitions; baseline events include resource context.

- **Dependencies**
  - Add `psutil>=5.9,<6.0`.

<sup>Written for commit 4a8ac0cc339a559bff883a54632f5228a691d919. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

