### PR TITLE
feat(sync): SESSION_SUMMARY.md to .docx conversion (NDBG-5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PYTHON = $(shell if [ -x .venv/bin/python ]; then echo .venv/bin/python; elif command -v python3 >/dev/null 2>&1; then echo python3; else echo python; fi)
 COMPOSE := docker-compose
 
-.PHONY: help bootstrap install install-dev check-venv up down build rebuild shell test test-docker coverage bandit safety security precommit clean
+.PHONY: help bootstrap install install-dev check-venv up down build rebuild shell test test-docker coverage bandit safety security precommit session-docx clean
 
 help:
 	@echo "NeuralDBG Make targets:"
@@ -22,6 +22,7 @@ help:
 	@echo "  make security      - run Bandit + Safety"
 	@echo "  make precommit     - run pre-commit hooks on all files"
 	@echo "  make check-venv    - verify/recreate .venv if Python version mismatch"
+	@echo "  make session-docx  - convert SESSION_SUMMARY.md to outputs/SESSION_SUMMARY.docx"
 	@echo "  make clean         - remove local QA artifacts"
 
 bootstrap:
@@ -73,6 +74,9 @@ security: bandit safety
 
 precommit:
 	$(PYTHON) -m pre_commit run --all-files
+
+session-docx: check-venv
+	$(PYTHON) scripts/session_to_docx.py
 
 clean:
 	rm -rf .pytest_cache htmlcov .mypy_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ automation = [
 mlops = [
     "mlflow>=2.13.0,<3.0.0",
 ]
+sync = [
+    "python-docx>=1.1.0,<2.0.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/Lemniscate-world/Neural"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ coverage>=7.0.0,<8.0.0
 bandit>=1.7.0,<2.0.0
 safety>=3.0.0,<4.0.0
 pre-commit>=3.0.0,<4.0.0
+python-docx>=1.1.0,<2.0.0

--- a/scripts/session_to_docx.py
+++ b/scripts/session_to_docx.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Convert SESSION_SUMMARY.md to a formatted .docx document.
+
+Parses markdown headings, bullet lists, bold text, and horizontal rules,
+then writes a styled Word document suitable for external communication.
+
+Usage:
+    python scripts/session_to_docx.py
+    python scripts/session_to_docx.py --source SESSION_SUMMARY.md --output out.docx
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+
+def _add_inline_bold(paragraph, text: str) -> None:
+    """Write text into *paragraph*, converting **bold** markers to bold runs."""
+    parts = re.split(r"(\*\*[^*]+\*\*)", text)
+    for part in parts:
+        if part.startswith("**") and part.endswith("**"):
+            run = paragraph.add_run(part[2:-2])
+            run.bold = True
+        elif part:
+            paragraph.add_run(part)
+
+
+def _parse_lines(lines: List[str]) -> List[Tuple[str, str]]:
+    """Convert raw markdown lines into (kind, content) tokens.
+
+    Kinds: heading1, heading2, heading3, bullet, hr, code, blank, paragraph.
+    """
+    tokens: List[Tuple[str, str]] = []
+    in_code = False
+    for line in lines:
+        stripped = line.rstrip("\n")
+        if stripped.startswith("```"):
+            in_code = not in_code
+            continue
+        if in_code:
+            tokens.append(("code", stripped))
+            continue
+        if re.match(r"^#{1}\s", stripped):
+            tokens.append(("heading1", stripped.lstrip("# ").strip()))
+        elif re.match(r"^#{2}\s", stripped):
+            tokens.append(("heading2", stripped.lstrip("# ").strip()))
+        elif re.match(r"^#{3}\s", stripped):
+            tokens.append(("heading3", stripped.lstrip("# ").strip()))
+        elif re.match(r"^[-*]\s", stripped):
+            tokens.append(("bullet", stripped[2:].strip()))
+        elif re.match(r"^---+$", stripped):
+            tokens.append(("hr", ""))
+        elif stripped == "":
+            tokens.append(("blank", ""))
+        else:
+            tokens.append(("paragraph", stripped))
+    return tokens
+
+
+def convert(source: Path, output: Path) -> None:
+    """Read *source* markdown and write a formatted .docx to *output*."""
+    try:
+        from docx import Document
+        from docx.shared import Pt, RGBColor
+        from docx.enum.text import WD_ALIGN_PARAGRAPH
+    except ImportError:
+        print(
+            "python-docx is required. Install with:\n"
+            "  pip install python-docx\n"
+            "  pip install -e .[sync]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not source.exists():
+        print(f"Source file not found: {source}", file=sys.stderr)
+        sys.exit(1)
+
+    lines = source.read_text(encoding="utf-8").splitlines(keepends=True)
+    tokens = _parse_lines(lines)
+
+    doc = Document()
+
+    # Narrow default margins for a cleaner look
+    for section in doc.sections:
+        section.top_margin = Pt(72)
+        section.bottom_margin = Pt(72)
+        section.left_margin = Pt(80)
+        section.right_margin = Pt(80)
+
+    for kind, content in tokens:
+        if kind == "heading1":
+            h = doc.add_heading(level=1)
+            h.clear()
+            run = h.add_run(content)
+            run.font.color.rgb = RGBColor(0x1A, 0x1A, 0x2E)
+        elif kind == "heading2":
+            h = doc.add_heading(level=2)
+            h.clear()
+            run = h.add_run(content)
+            run.font.color.rgb = RGBColor(0x16, 0x21, 0x3E)
+        elif kind == "heading3":
+            h = doc.add_heading(level=3)
+            h.clear()
+            run = h.add_run(content)
+        elif kind == "bullet":
+            p = doc.add_paragraph(style="List Bullet")
+            _add_inline_bold(p, content)
+        elif kind == "hr":
+            # Horizontal rule rendered as a thin paragraph border
+            p = doc.add_paragraph()
+            pPr = p._p.get_or_add_pPr()
+            from docx.oxml.ns import qn
+            from docx.oxml import OxmlElement
+            pBdr = OxmlElement("w:pBdr")
+            bottom = OxmlElement("w:bottom")
+            bottom.set(qn("w:val"), "single")
+            bottom.set(qn("w:sz"), "6")
+            bottom.set(qn("w:space"), "1")
+            bottom.set(qn("w:color"), "AAAAAA")
+            pBdr.append(bottom)
+            pPr.append(pBdr)
+        elif kind == "code":
+            p = doc.add_paragraph()
+            run = p.add_run(content)
+            run.font.name = "Courier New"
+            run.font.size = Pt(9)
+        elif kind == "paragraph":
+            p = doc.add_paragraph()
+            _add_inline_bold(p, content)
+        # blank lines are intentionally skipped (Word handles spacing via styles)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(str(output))
+    print(f"Saved: {output}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert SESSION_SUMMARY.md to a formatted .docx"
+    )
+    parser.add_argument(
+        "--source",
+        default="SESSION_SUMMARY.md",
+        help="Path to input markdown file (default: SESSION_SUMMARY.md)",
+    )
+    parser.add_argument(
+        "--output",
+        default="outputs/SESSION_SUMMARY.docx",
+        help="Path for output .docx (default: outputs/SESSION_SUMMARY.docx)",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    convert(Path(args.source), Path(args.output))

--- a/tests/unit/test_session_to_docx.py
+++ b/tests/unit/test_session_to_docx.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for scripts/session_to_docx.py (NDBG-5).
+
+Verifies markdown parsing, docx generation, and cross-platform path handling.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the scripts/ directory importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from session_to_docx import _parse_lines, _add_inline_bold, convert
+
+
+class TestParseLines:
+    """Tokeniser covers all markdown constructs present in SESSION_SUMMARY.md."""
+
+    def test_heading1(self):
+        tokens = _parse_lines(["# My Title\n"])
+        assert tokens == [("heading1", "My Title")]
+
+    def test_heading2(self):
+        tokens = _parse_lines(["## Section\n"])
+        assert tokens == [("heading2", "Section")]
+
+    def test_heading3(self):
+        tokens = _parse_lines(["### Sub\n"])
+        assert tokens == [("heading3", "Sub")]
+
+    def test_bullet_dash(self):
+        tokens = _parse_lines(["- item one\n"])
+        assert tokens == [("bullet", "item one")]
+
+    def test_bullet_star(self):
+        tokens = _parse_lines(["* item two\n"])
+        assert tokens == [("bullet", "item two")]
+
+    def test_horizontal_rule(self):
+        tokens = _parse_lines(["---\n"])
+        assert tokens == [("hr", "")]
+
+    def test_blank_line(self):
+        tokens = _parse_lines(["\n"])
+        assert tokens == [("blank", "")]
+
+    def test_plain_paragraph(self):
+        tokens = _parse_lines(["Hello world\n"])
+        assert tokens == [("paragraph", "Hello world")]
+
+    def test_code_block_skipped(self):
+        lines = ["```python\n", "x = 1\n", "```\n"]
+        tokens = _parse_lines(lines)
+        assert ("code", "x = 1") in tokens
+        # fence markers themselves are consumed
+        kinds = [k for k, _ in tokens]
+        assert "heading1" not in kinds
+
+    def test_mixed_content(self):
+        lines = [
+            "# Title\n",
+            "\n",
+            "## English\n",
+            "- bullet\n",
+            "---\n",
+        ]
+        tokens = _parse_lines(lines)
+        assert tokens[0] == ("heading1", "Title")
+        assert tokens[1] == ("blank", "")
+        assert tokens[2] == ("heading2", "English")
+        assert tokens[3] == ("bullet", "bullet")
+        assert tokens[4] == ("hr", "")
+
+
+class TestInlineBold:
+    """_add_inline_bold splits text on **...** markers and sets bold correctly."""
+
+    def test_plain_text(self, tmp_path):
+        from docx import Document
+        doc = Document()
+        p = doc.add_paragraph()
+        _add_inline_bold(p, "plain text")
+        runs = p.runs
+        assert len(runs) == 1
+        assert runs[0].text == "plain text"
+        assert not runs[0].bold
+
+    def test_bold_only(self, tmp_path):
+        from docx import Document
+        doc = Document()
+        p = doc.add_paragraph()
+        _add_inline_bold(p, "**bold**")
+        runs = p.runs
+        assert any(r.bold and r.text == "bold" for r in runs)
+
+    def test_mixed_bold(self, tmp_path):
+        from docx import Document
+        doc = Document()
+        p = doc.add_paragraph()
+        _add_inline_bold(p, "before **bold** after")
+        texts = [r.text for r in p.runs]
+        assert "before " in texts
+        assert "bold" in texts
+        assert " after" in texts
+        bold_runs = [r for r in p.runs if r.bold]
+        assert len(bold_runs) == 1
+        assert bold_runs[0].text == "bold"
+
+
+class TestConvert:
+    """End-to-end: convert() writes a valid .docx from markdown input."""
+
+    SAMPLE_MD = """\
+# Session Summary -- 2026-05-11 (Test)
+**Editor**: Claude
+
+## Francais
+**Ce qui a ete fait** :
+- Premiere tache accomplie
+- Deuxieme tache
+
+---
+
+## English
+**What was done**:
+- First task done
+- Second task
+"""
+
+    def test_output_file_created(self, tmp_path):
+        src = tmp_path / "SESSION_SUMMARY.md"
+        src.write_text(self.SAMPLE_MD, encoding="utf-8")
+        out = tmp_path / "out.docx"
+        convert(src, out)
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_output_contains_headings(self, tmp_path):
+        from docx import Document
+        src = tmp_path / "SESSION_SUMMARY.md"
+        src.write_text(self.SAMPLE_MD, encoding="utf-8")
+        out = tmp_path / "out.docx"
+        convert(src, out)
+        doc = Document(str(out))
+        heading_texts = [p.text for p in doc.paragraphs if p.style.name.startswith("Heading")]
+        assert any("Session Summary" in t for t in heading_texts)
+        assert any("Francais" in t for t in heading_texts)
+        assert any("English" in t for t in heading_texts)
+
+    def test_output_contains_bullets(self, tmp_path):
+        from docx import Document
+        src = tmp_path / "SESSION_SUMMARY.md"
+        src.write_text(self.SAMPLE_MD, encoding="utf-8")
+        out = tmp_path / "out.docx"
+        convert(src, out)
+        doc = Document(str(out))
+        bullet_texts = [p.text for p in doc.paragraphs if "List" in p.style.name]
+        assert any("First task done" in t for t in bullet_texts)
+
+    def test_missing_source_exits(self, tmp_path):
+        src = tmp_path / "nonexistent.md"
+        out = tmp_path / "out.docx"
+        with pytest.raises(SystemExit):
+            convert(src, out)
+
+    def test_output_dir_created_automatically(self, tmp_path):
+        src = tmp_path / "SESSION_SUMMARY.md"
+        src.write_text(self.SAMPLE_MD, encoding="utf-8")
+        out = tmp_path / "subdir" / "nested" / "out.docx"
+        convert(src, out)
+        assert out.exists()


### PR DESCRIPTION
## Summary

- Adds `scripts/session_to_docx.py`: converts `SESSION_SUMMARY.md` to a formatted `.docx` via `python-docx` — no system dependencies, cross-platform (Linux/Windows)
- Parses H1–H3 headings, bullet lists (`-`/`*`), inline bold (`**...**`), horizontal rules, and fenced code blocks
- Output path defaults to `outputs/SESSION_SUMMARY.docx`; parent directories created automatically
- Adds `python-docx>=1.1.0` to `[sync]` optional dep group and `requirements-dev.txt`
- Adds `make session-docx` Makefile target

## Usage

```bash
make session-docx
# or directly:
python scripts/session_to_docx.py --source SESSION_SUMMARY.md --output outputs/SESSION_SUMMARY.docx
```

## Test plan

- [x] `_parse_lines` — 9 tokeniser tests (H1/H2/H3, bullet dash/star, HR, blank, paragraph, code block, mixed)
- [x] `_add_inline_bold` — 3 tests (plain, bold-only, mixed)
- [x] `convert` — 5 end-to-end tests: file created, headings present, bullets present, missing source exits with error, nested output dir auto-created
- [x] Full suite: 101 passed, 4 skipped (torch.compile), 0 failed

Closes NDBG-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-platform script to convert SESSION_SUMMARY.md into a styled .docx and a Makefile target to run it. Implements NDBG-5 by enabling easy export of session summaries for external sharing.

- **New Features**
  - `scripts/session_to_docx.py` converts markdown (H1–H3, bullets, `**bold**`, horizontal rules, fenced code) to Word.
  - Default output is `outputs/SESSION_SUMMARY.docx`; creates parent dirs and errors clearly if source is missing.
  - `make session-docx` runs the conversion.

- **Dependencies**
  - Adds `python-docx>=1.1.0,<2.0.0` under `[sync]` and in `requirements-dev.txt`.

<sup>Written for commit 0f2ac4bdfb0867ec64a1261a29bca6ffbba6ba83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

